### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask==2.0.1
 Flask-MySQLdb==0.2.0
 requests==2.26.0
+Werkzeug==2.0.1
 


### PR DESCRIPTION
I encountered the error as my docker container got exited after creating it from docker image.

After checking the docker logs I found the below error;

634c41109fd3   flaskapp:latest   "python app.py"   About a minute ago   Exited (1) About a minute ago             practical_wilbur
ubuntu@ip-172-31-92-203:~/two-tier-flask-app$ docker logs 634c
Traceback (most recent call last):
  File "/app/app.py", line 2, in <module>
    from flask import Flask, render_template, request, redirect, url_for
  File "/usr/local/lib/python3.9/site-packages/flask/__init__.py", line 7, in <module>
    from .app import Flask as Flask
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 28, in <module>
    from . import cli
  File "/usr/local/lib/python3.9/site-packages/flask/cli.py", line 18, in <module>
    from .helpers import get_debug_flag
  File "/usr/local/lib/python3.9/site-packages/flask/helpers.py", line 16, in <module>
    from werkzeug.urls import url_quote
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.9/site-packages/werkzeug/urls.py

After adding the "Werkzeug==2.0.1" in requirement.txt file,the issue got resolved.
So kindly review this and accept my pull request, if necessary.