### PR TITLE
Updated MySql Docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ docker network create twotier
 
 i) MySQL container 
 ```bash
-docker run -d --name mysql -v mysql-data:/var/lib/mysql -v ./message.sql:/docker-entrypoint-initdb.d/message.sql --network=twotier -e MYSQL_DATABASE=mydb -e MYSQL_USER=root -e MYSQL_ROOT_PASSWORD="admin" -p 3360:3360 mysql:5.7
+docker run -d --name mysql -v mysql-data:/var/lib/mysql -v ./message.sql:/docker-entrypoint-initdb.d/message.sql --network=twotier -e MYSQL_DATABASE=mydb -e MYSQL_ROOT_PASSWORD="admin" -p 3360:3360 mysql:5.7
 ```
 ii) Backend container
 ```bash


### PR DESCRIPTION
Resolution suggested by MySql :

ubuntu@ip-172-31-19-26:~/two-tier-flask-app$ docker logs 74 2023-10-16 19:23:10+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.7.43-1.el7 started. 2023-10-16 19:23:10+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql' 2023-10-16 19:23:10+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.7.43-1.el7 started. 2023-10-16 19:23:11+00:00 [ERROR] [Entrypoint]: MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD are for configuring a regular user and cannot be used for the root user
    Remove MYSQL_USER="root" and use one of the following to control the root user password:
    - MYSQL_ROOT_PASSWORD
    - MYSQL_ALLOW_EMPTY_PASSWORD
    - MYSQL_RANDOM_ROOT_PASSWORD