### PR TITLE
I faced the issue while running Docker file- ignoring apt-sources.list URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ FROM python:3.9-slim
 WORKDIR /app
 
 # install required packages for system
-RUN apt-get update \
-    && apt-get upgrade -y \
+RUN sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/debian.sources \
+    && apt-get update \
+    && apt-get upgrade \
     && apt-get install -y gcc default-libmysqlclient-dev pkg-config \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 # install required packages for system
 RUN sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/debian.sources \
     && apt-get update \
-    && apt-get upgrade \
+    && apt-get upgrade -y \
     && apt-get install -y gcc default-libmysqlclient-dev pkg-config \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Hi,

When I ran the Docker file, I got issue unable to install packages within the container as by default debian using the http URL which runs on 80 port by default and system is keep ignoring the URL, so i modified the URL from http to https with sed command and afterwards it pulls the packages with secure 443 port due to https in URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system package installation to use secure HTTPS sources for Debian packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->